### PR TITLE
:heavy_minus_sign: Remove dependency on `stdx`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .cmake-format.yaml
 CMakePresets.json
 /toolchains
+mull.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,8 @@ else()
     cpmaddpackage("gh:intel/cicd-repo-infrastructure#3e2bef0")
 endif()
 
-add_versioned_package("gh:intel/cpp-std-extensions#dc6352e")
-
 add_library(concurrency INTERFACE)
 target_compile_features(concurrency INTERFACE cxx_std_20)
-target_link_libraries_system(concurrency INTERFACE stdx)
 
 target_sources(
     concurrency

--- a/include/conc/concepts.hpp
+++ b/include/conc/concepts.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <stdx/concepts.hpp>
+#include <concepts>
 
 namespace conc {
 template <typename T>
 concept concurrency_policy =
     requires(auto (*f)()->int &&, auto (*pred)()->bool) {
-        { T::call_in_critical_section(f) } -> stdx::same_as<int &&>;
-        { T::call_in_critical_section(f, pred) } -> stdx::same_as<int &&>;
+        { T::call_in_critical_section(f) } -> std::same_as<int &&>;
+        { T::call_in_critical_section(f, pred) } -> std::same_as<int &&>;
     };
 } // namespace conc

--- a/include/conc/concurrency.hpp
+++ b/include/conc/concurrency.hpp
@@ -6,24 +6,25 @@
 #define HAS_MUTEX __has_include(<mutex>)
 #endif
 
-#include <stdx/concepts.hpp>
-#include <stdx/type_traits.hpp>
+#include <conc/concepts.hpp>
 
 #if HAS_MUTEX
 #include <mutex>
 #endif
-#include <conc/concepts.hpp>
 
+#include <concepts>
 #include <utility>
 
 namespace conc {
 namespace detail {
+template <typename...> constexpr auto always_false_v = false;
+
 #if HAS_MUTEX
 template <typename Mutex = std::mutex> class standard_policy {
     template <typename> static inline Mutex m{};
 
   public:
-    template <typename Uniq = void, stdx::invocable F, stdx::predicate... Pred>
+    template <typename Uniq = void, std::invocable F, std::predicate... Pred>
         requires(sizeof...(Pred) < 2)
     static inline auto call_in_critical_section(F &&f, auto &&...pred)
         -> decltype(std::forward<F>(f)()) {
@@ -37,13 +38,13 @@ template <typename Mutex = std::mutex> class standard_policy {
 };
 #else
 template <typename = void> struct standard_policy {
-    template <typename = void, stdx::invocable F, stdx::predicate... Pred>
+    template <typename = void, std::invocable F, std::predicate... Pred>
         requires(sizeof...(Pred) < 2)
     static inline auto call_in_critical_section(F &&f, Pred &&...)
         -> decltype(std::forward<F>(f)()) {
-        static_assert(
-            stdx::always_false_v<F, Pred...>,
-            "No standard concurrency policy defined: inject a policy");
+        static_assert(always_false_v<F, Pred...>,
+                      "No standard concurrency policy defined: inject a policy "
+                      "by specializing conc::injected_policy<>");
         return std::forward<F>(f)();
     }
 };
@@ -53,7 +54,7 @@ template <typename = void> struct standard_policy {
 template <typename...> inline auto injected_policy = detail::standard_policy{};
 
 template <typename Uniq = decltype([] {}), typename... DummyArgs,
-          stdx::invocable F, stdx::predicate... Pred>
+          std::invocable F, std::predicate... Pred>
     requires(sizeof...(DummyArgs) == 0 and sizeof...(Pred) < 2)
 inline auto call_in_critical_section(F &&f, Pred &&...pred)
     -> decltype(std::forward<F>(f)()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,3 +34,5 @@ add_unit_test(
     warnings
     concurrency
     pthread)
+
+add_compile_fail_test(fail_no_policy.cpp LIBRARIES concurrency)

--- a/test/fail_no_policy.cpp
+++ b/test/fail_no_policy.cpp
@@ -1,0 +1,9 @@
+#define SIMULATE_FREESTANDING
+
+#include <conc/concurrency.hpp>
+
+// EXPECT: No standard concurrency policy defined: inject a policy
+
+auto main() -> int {
+    conc::call_in_critical_section([] {});
+}

--- a/test/freestanding_injected_policy.cpp
+++ b/test/freestanding_injected_policy.cpp
@@ -3,11 +3,10 @@
 #include <conc/concepts.hpp>
 #include <conc/concurrency.hpp>
 
-#include <stdx/concepts.hpp>
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <atomic>
+#include <concepts>
 #include <cstdint>
 #include <utility>
 
@@ -19,7 +18,7 @@ auto test_before_definition() {
 struct custom_policy {
     static inline std::atomic<std::uint64_t> count{};
 
-    template <typename = void, stdx::invocable F, stdx::predicate... Pred>
+    template <typename = void, std::invocable F, std::predicate... Pred>
         requires(sizeof...(Pred) < 2)
     static inline auto
     call_in_critical_section(F &&f, auto &&...pred) -> decltype(auto) {

--- a/test/hosted_injected_policy.cpp
+++ b/test/hosted_injected_policy.cpp
@@ -1,11 +1,10 @@
 #include <conc/concepts.hpp>
 #include <conc/concurrency.hpp>
 
-#include <stdx/concepts.hpp>
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <atomic>
+#include <concepts>
 #include <cstdint>
 #include <utility>
 
@@ -17,7 +16,7 @@ auto test_before_definition() {
 struct custom_policy {
     static inline std::atomic<std::uint64_t> count{};
 
-    template <typename = void, stdx::invocable F, stdx::predicate... Pred>
+    template <typename = void, std::invocable F, std::predicate... Pred>
         requires(sizeof...(Pred) < 2)
     static inline auto
     call_in_critical_section(F &&f, auto &&...pred) -> decltype(auto) {


### PR DESCRIPTION
Problem:
- `concurrency` is a platform-level library but depends on `stdx`: in reality, `stdx` may want constructs that should depend on `concurrency`.

Solution:
- Remove the dependency.

Note:
- `concurrency` was only using `invocable` and `predicate` concepts, and `always_false_v`. `always_false_v` is easily implemented inside `concurrency`, and the two concepts are standard from C++20. Since `concurrency` already uses C++20, it's fine to use the standard versions.