### PR TITLE
:construction_worker: Update fileset to include `atomic.hpp`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(
               BASE_DIRS
               include
               FILES
+              include/conc/atomic.hpp
               include/conc/concepts.hpp
               include/conc/concurrency.hpp)
 

--- a/include/conc/atomic.hpp
+++ b/include/conc/atomic.hpp
@@ -6,6 +6,10 @@
 #include <memory>
 #include <type_traits>
 
+// NOLINTBEGIN(modernize-use-constraints)
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg)
+
 #if __cplusplus >= 202002L
 #define CPP20(...) __VA_ARGS__
 #else
@@ -192,6 +196,10 @@ constexpr inline auto alignment_of = alignof(std::atomic<atomic_type_t<T>>);
 } // namespace atomic
 
 #undef CPP20
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg)
+// NOLINTEND(cppcoreguidelines-macro-usage)
+// NOLINTEND(modernize-use-constraints)
 
 #ifdef ATOMIC_CFG
 #include ATOMIC_CFG


### PR DESCRIPTION
Problem:
- `atomic.hpp` is not included in the library fileset; therefore it is not clang-tidied either.

Solution:
- Fix the fileset.
- Fix up clang-tidy for `atomic.hpp` (turning off a few tidies because it's C++17 and must call intrinsics).