### PR TITLE
:white_check_mark: Use `STATIC_REQUIRE` instead of `static_assert`

### DIFF
--- a/test/atomic_injected_policy.cpp
+++ b/test/atomic_injected_policy.cpp
@@ -25,7 +25,7 @@ template <> inline auto atomic::injected_policy<> = custom_policy{};
 
 #if __cplusplus >= 202002L
 TEST_CASE("injected policy models load_store", "[atomic_injected_policy]") {
-    static_assert(atomic::load_store_policy<custom_policy>);
+    STATIC_REQUIRE(atomic::load_store_policy<custom_policy>);
 }
 #endif
 
@@ -42,11 +42,11 @@ TEST_CASE("injected policy implements store", "[atomic_injected_policy]") {
 
 TEST_CASE("injected policy can inject different atomic types",
           "[atomic_injected_policy]") {
-    static_assert(std::is_same_v<atomic::atomic_type_t<bool>, std::uint32_t>);
-    static_assert(atomic::alignment_of<bool> == alignof(std::uint32_t));
+    STATIC_REQUIRE(std::is_same_v<atomic::atomic_type_t<bool>, std::uint32_t>);
+    STATIC_REQUIRE(atomic::alignment_of<bool> == alignof(std::uint32_t));
 }
 
 TEST_CASE("injected policy can inject different atomic alignments",
           "[atomic_injected_policy]") {
-    static_assert(atomic::alignment_of<std::uint8_t> == 4);
+    STATIC_REQUIRE(atomic::alignment_of<std::uint8_t> == 4);
 }

--- a/test/atomic_standard_policy.cpp
+++ b/test/atomic_standard_policy.cpp
@@ -9,11 +9,11 @@
 
 #if __cplusplus >= 202002L
 TEST_CASE("standard policy models concepts", "[atomic_standard_policy]") {
-    static_assert(atomic::load_store_policy<atomic::detail::standard_policy>);
-    static_assert(atomic::exchange_policy<atomic::detail::standard_policy>);
-    static_assert(atomic::add_sub_policy<atomic::detail::standard_policy>);
-    static_assert(atomic::bitwise_policy<atomic::detail::standard_policy>);
-    static_assert(atomic::policy<atomic::detail::standard_policy>);
+    STATIC_REQUIRE(atomic::load_store_policy<atomic::detail::standard_policy>);
+    STATIC_REQUIRE(atomic::exchange_policy<atomic::detail::standard_policy>);
+    STATIC_REQUIRE(atomic::add_sub_policy<atomic::detail::standard_policy>);
+    STATIC_REQUIRE(atomic::bitwise_policy<atomic::detail::standard_policy>);
+    STATIC_REQUIRE(atomic::policy<atomic::detail::standard_policy>);
 }
 #endif
 
@@ -138,11 +138,11 @@ TEST_CASE("standard policy implements fetch_xor atomically",
 TEMPLATE_TEST_CASE("standard policy has normal types",
                    "[atomic_standard_policy]", bool, std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
-    static_assert(std::is_same_v<atomic::atomic_type_t<TestType>, TestType>);
+    STATIC_REQUIRE(std::is_same_v<atomic::atomic_type_t<TestType>, TestType>);
 }
 
 TEMPLATE_TEST_CASE("standard policy has normal alignment",
                    "[atomic_standard_policy]", bool, std::uint8_t,
                    std::uint16_t, std::uint32_t, std::uint64_t) {
-    static_assert(atomic::alignment_of<TestType> == alignof(TestType));
+    STATIC_REQUIRE(atomic::alignment_of<TestType> == alignof(TestType));
 }

--- a/test/concepts.cpp
+++ b/test/concepts.cpp
@@ -32,10 +32,10 @@ struct not_a_policy {};
 } // namespace
 
 TEST_CASE("concurrency_policy", "[concepts]") {
-    static_assert(conc::policy<good_conc_policy>);
-    static_assert(not conc::policy<not_a_policy>);
-    static_assert(not conc::policy<bad_conc_policy_return_decay>);
-    static_assert(not conc::policy<bad_conc_policy_no_pred>);
+    STATIC_REQUIRE(conc::policy<good_conc_policy>);
+    STATIC_REQUIRE(not conc::policy<not_a_policy>);
+    STATIC_REQUIRE(not conc::policy<bad_conc_policy_return_decay>);
+    STATIC_REQUIRE(not conc::policy<bad_conc_policy_no_pred>);
 }
 
 namespace {
@@ -85,12 +85,12 @@ struct atomic_policy : atomic_exchange_policy,
 } // namespace
 
 TEST_CASE("good atomic policies", "[concepts]") {
-    static_assert(atomic::load_store_policy<atomic_load_store_policy>);
-    static_assert(atomic::exchange_policy<atomic_exchange_policy>);
-    static_assert(atomic::add_sub_policy<atomic_add_sub_policy>);
-    static_assert(atomic::bitwise_policy<atomic_bitwise_policy>);
-    static_assert(atomic::policy<atomic_policy>);
-    static_assert(not atomic::policy<not_a_policy>);
+    STATIC_REQUIRE(atomic::load_store_policy<atomic_load_store_policy>);
+    STATIC_REQUIRE(atomic::exchange_policy<atomic_exchange_policy>);
+    STATIC_REQUIRE(atomic::add_sub_policy<atomic_add_sub_policy>);
+    STATIC_REQUIRE(atomic::bitwise_policy<atomic_bitwise_policy>);
+    STATIC_REQUIRE(atomic::policy<atomic_policy>);
+    STATIC_REQUIRE(not atomic::policy<not_a_policy>);
 }
 
 namespace {
@@ -120,10 +120,11 @@ struct bad_exchange_policy_no_return : atomic_load_store_policy {
 } // namespace
 
 TEST_CASE("bad atomic policies", "[concepts]") {
-    static_assert(not atomic::load_store_policy<bad_load_store_policy_no_load>);
-    static_assert(
+    STATIC_REQUIRE(
+        not atomic::load_store_policy<bad_load_store_policy_no_load>);
+    STATIC_REQUIRE(
         not atomic::load_store_policy<bad_load_store_policy_no_store>);
-    static_assert(
+    STATIC_REQUIRE(
         not atomic::load_store_policy<bad_load_store_policy_no_memory_order>);
-    static_assert(not atomic::exchange_policy<bad_exchange_policy_no_return>);
+    STATIC_REQUIRE(not atomic::exchange_policy<bad_exchange_policy_no_return>);
 }

--- a/test/freestanding_conc_injected_policy.cpp
+++ b/test/freestanding_conc_injected_policy.cpp
@@ -35,11 +35,11 @@ struct custom_policy {
 template <> inline auto conc::injected_policy<> = custom_policy{};
 
 TEST_CASE("standard policy models concept", "[freestanding_injected_policy]") {
-    static_assert(conc::policy<conc::detail::standard_policy<>>);
+    STATIC_REQUIRE(conc::policy<conc::detail::standard_policy<>>);
 }
 
 TEST_CASE("custom policy models concept", "[freestanding_injected_policy]") {
-    static_assert(conc::policy<custom_policy>);
+    STATIC_REQUIRE(conc::policy<custom_policy>);
 }
 
 TEST_CASE("injected custom policy is used", "[freestanding_injected_policy]") {

--- a/test/hosted_conc_injected_policy.cpp
+++ b/test/hosted_conc_injected_policy.cpp
@@ -38,11 +38,11 @@ struct custom_policy {
 template <> inline auto conc::injected_policy<> = custom_policy{};
 
 TEST_CASE("standard policy models concept", "[hosted_injected_policy]") {
-    static_assert(conc::policy<conc::detail::standard_policy<>>);
+    STATIC_REQUIRE(conc::policy<conc::detail::standard_policy<>>);
 }
 
 TEST_CASE("custom policy models concept", "[hosted_injected_policy]") {
-    static_assert(conc::policy<custom_policy>);
+    STATIC_REQUIRE(conc::policy<custom_policy>);
 }
 
 TEST_CASE("injected custom policy is used", "[hosted_injected_policy]") {


### PR DESCRIPTION
Problem:
- Using static_assert does not report the check in Catch2.

Solution:
- Use STATIC_REQUIRE so that the check is reported.