### PR TITLE
:books: Update README for compiler versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ concurrent execution.
 C++20 is required to use the `conc` namespace functionality; C++17 will suffice
 for the `atomic` namespace functionality. The following compilers are supported:
  
-- clang 14 through 19
-- gcc 12 through 13
+- clang 14 through 21
+- gcc 12 through 14
 
 See the [full documentation](https://intel.github.io/cpp-baremetal-concurrency/).


### PR DESCRIPTION
Problem:
- The `README.md` file does not report support for the latest compilers.

Solution:
- Update the file to reflect support.