### PR TITLE
:white_check_mark: Add usage test for freestanding

### DIFF
--- a/.github/workflows/usage_test.yml
+++ b/.github/workflows/usage_test.yml
@@ -1,0 +1,45 @@
+name: Usage Test
+permissions: read-all
+
+on:
+  workflow_dispatch:
+  merge_group:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  USER_LLVM_VERSION: 14
+  USER_CMAKE_VERSION: 3.25
+
+jobs:
+  usage_test:
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        freestanding: [0, 1]
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install compiler
+        run: sudo apt update && sudo apt-get install -y clang-${{env.USER_LLVM_VERSION}}
+
+      - name: Install cmake
+        run: |
+          pip3 install --upgrade pip
+          pip3 install --force cmake==${{env.USER_CMAKE_VERSION}}
+
+      - name: Configure CMake
+        working-directory: ${{github.workspace}}/usage_test
+        env:
+          CC: "/usr/lib/llvm-${{env.USER_LLVM_VERSION}}/bin/clang"
+          CXX: "/usr/lib/llvm-${{env.USER_LLVM_VERSION}}/bin/clang++"
+        run: ~/.local/bin/cmake -B build -DSIMULATE_FREESTANDING=${{matrix.freestanding}}
+
+      - name: Build
+        working-directory: ${{github.workspace}}/usage_test
+        run: ~/.local/bin/cmake --build build

--- a/usage_test/CMakeLists.txt
+++ b/usage_test/CMakeLists.txt
@@ -1,0 +1,17 @@
+if(DEFINED ENV{USER_CMAKE_VERSION})
+    message(STATUS "Required minimum cmake version: $ENV{USER_CMAKE_VERSION}")
+    cmake_minimum_required(VERSION $ENV{USER_CMAKE_VERSION})
+endif()
+message(STATUS "Actual cmake version: ${CMAKE_VERSION}")
+
+project(conc_usage)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/get_cpm.cmake)
+cpmaddpackage(NAME conc SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/.." GIT_TAG HEAD)
+
+add_executable(app main.cpp)
+target_link_libraries(app PRIVATE concurrency)
+if(SIMULATE_FREESTANDING)
+    target_compile_definitions(app PRIVATE SIMULATE_FREESTANDING)
+    target_compile_options(app PRIVATE -ffreestanding)
+endif()

--- a/usage_test/main.cpp
+++ b/usage_test/main.cpp
@@ -1,0 +1,8 @@
+#include <conc/atomic.hpp>
+#include <conc/concurrency.hpp>
+
+#if __STDC_HOSTED__ == 0
+extern "C" auto main() -> int;
+#endif
+
+auto main() -> int { return 0; }


### PR DESCRIPTION
Problem:
- This library should be usable with `-ffreestanding`, but there is no test for that.

Solution:
- Add a usage test.