### PR TITLE
:art: :construction_worker: Improve freestanding/hosted usage test naming

### DIFF
--- a/.github/workflows/usage_test.yml
+++ b/.github/workflows/usage_test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        freestanding: [0, 1]
+        cpp_implementation: [FREESTANDING, HOSTED]
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -38,7 +38,7 @@ jobs:
         env:
           CC: "/usr/lib/llvm-${{env.USER_LLVM_VERSION}}/bin/clang"
           CXX: "/usr/lib/llvm-${{env.USER_LLVM_VERSION}}/bin/clang++"
-        run: ~/.local/bin/cmake -B build -DSIMULATE_FREESTANDING=${{matrix.freestanding}}
+        run: ~/.local/bin/cmake -B build -DCPP_IMPLEMENTATION=${{matrix.cpp_implementation}}
 
       - name: Build
         working-directory: ${{github.workspace}}/usage_test

--- a/usage_test/CMakeLists.txt
+++ b/usage_test/CMakeLists.txt
@@ -11,7 +11,7 @@ cpmaddpackage(NAME conc SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/.." GIT_TAG HEAD)
 
 add_executable(app main.cpp)
 target_link_libraries(app PRIVATE concurrency)
-if(SIMULATE_FREESTANDING)
+if(CPP_IMPLEMENTATION STREQUAL "FREESTANDING")
     target_compile_definitions(app PRIVATE SIMULATE_FREESTANDING)
     target_compile_options(app PRIVATE -ffreestanding)
 endif()


### PR DESCRIPTION
Problem:
- In CI, the usage test is named `usage_test(0)` or `usage_test(1)`. It is not obvious what the `0` and `1` mean.

Solution:
- Change to `FREESTANDING` vs `HOSTED` to make it clear what the usage test refers to.