### PR TITLE
:page_facing_up: Add AI policy to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,17 @@ Use your real name (sorry, no pseudonyms or anonymous contributions.)
 
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.
+
+### Use of AI in contributions
+
+The current policy of this project is to decline any contributions which are
+believed to include or derive from AI generated content. This includes ChatGPT,
+Claude, Copilot, Llama and similar tools.
+
+Contributors should refrain from including AI-/LLM-generated content in pull
+requests submitted to this project. Any pull request which is known or suspected
+to include such content will be declined and closed.
+
+This policy does not apply to other uses of AI such as research or debugging,
+provided their output is not included in contributions.
+


### PR DESCRIPTION
Problem:
- Open source projects are increasingly facing AI-generated contributions. We have no clear policy on this matter.

Solution:
- Add a policy statement to `CONTRIBUTING.md`.

Note:
- We state the policy as clearly and objectively as possible without subjective argument or justification.