### PR TITLE
:sparkles: :construction_worker: Add clang-22 build

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,11 +13,11 @@ env:
   DEBIAN_FRONTEND: noninteractive
   CMAKE_GENERATOR: Ninja
   DEFAULT_CXX_STANDARD: 23
-  DEFAULT_LLVM_VERSION: 21
+  DEFAULT_LLVM_VERSION: 22
   DEFAULT_GCC_VERSION: 14
-  MULL_LLVM_MAJOR_VERSION: 19
-  MULL_LLVM_VERSION: 19.1.1
-  MULL_VERSION: 0.27.1
+  MULL_LLVM_MAJOR_VERSION: 20
+  MULL_LLVM_VERSION: 20.1.2
+  MULL_VERSION: 0.29.0
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang, gcc]
-        version: [12, 13, 14, 18, 19, 20, 21]
+        version: [12, 13, 14, 18, 19, 20, 21, 22]
         cxx_standard: [23]
         stdlib: [libstdc++, libc++]
         build_type: [Debug]
@@ -39,62 +39,60 @@ jobs:
             cc: "clang"
             cxx: "clang++"
             cxx_flags: "-stdlib=libstdc++"
+          - version: 22
+            compiler: clang
+            toolchain_root: "/usr/lib/llvm-22"
+          - version: 22
+            compiler: clang
+            stdlib: libc++
+            cxx_flags: "-stdlib=libc++"
           - version: 21
             compiler: clang
-            install: sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 21
             toolchain_root: "/usr/lib/llvm-21"
           - version: 21
             compiler: clang
             stdlib: libc++
-            install: sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 21 && sudo apt install -y libc++-21-dev libc++abi-21-dev
             cxx_flags: "-stdlib=libc++"
           - version: 20
             compiler: clang
-            install: sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 20
             toolchain_root: "/usr/lib/llvm-20"
           - version: 20
             compiler: clang
             stdlib: libc++
-            install: sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 20 && sudo apt install -y libc++-20-dev libc++abi-20-dev
             cxx_flags: "-stdlib=libc++"
           - version: 19
             compiler: clang
-            install: sudo apt update && sudo apt install -y clang-19
             toolchain_root: "/usr/lib/llvm-19"
           - version: 19
             compiler: clang
             stdlib: libc++
-            install: sudo apt update && sudo apt install -y clang-19 libc++-19-dev libc++abi-19-dev
             cxx_flags: "-stdlib=libc++"
           - version: 18
             compiler: clang
-            install: sudo apt update && sudo apt install -y clang-18
             toolchain_root: "/usr/lib/llvm-18"
           - version: 18
             compiler: clang
             stdlib: libc++
-            install: sudo apt update && sudo apt install -y clang-18 libc++-18-dev libc++abi-18-dev
             cxx_flags: "-stdlib=libc++"
           - compiler: gcc
             toolchain_root: "/usr"
             cxx_flags: ""
           - version: 14
             compiler: gcc
-            install: sudo apt update && sudo apt install -y gcc-14 g++-14
             cc: "gcc-14"
             cxx: "g++-14"
           - version: 13
             compiler: gcc
-            install: sudo apt update && sudo apt install -y gcc-13 g++-13
             cc: "gcc-13"
             cxx: "g++-13"
           - version: 12
             compiler: gcc
-            install: sudo apt update && sudo apt install -y gcc-12 g++-12
             cc: "gcc-12"
             cxx: "g++-12"
             cxx_flags: ""
         exclude:
+          - compiler: gcc
+            version: 22
           - compiler: gcc
             version: 21
           - compiler: gcc
@@ -117,8 +115,14 @@ jobs:
 
       - name: Install build tools
         run: |
-          ${{ matrix.install }}
-          sudo apt install -y ninja-build
+          if [[ "${{matrix.compiler}}" == "clang" ]]; then
+            export DISTRO=$(lsb_release -cs)
+            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+            sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{matrix.version}} main
+            sudo apt update && sudo apt install -y ninja-build clang-${{matrix.version}} libc++-${{matrix.version}}-dev libc++abi-${{matrix.version}}-dev
+          else
+            sudo apt update && sudo apt install -y ninja-build gcc-${{matrix.version}} g++-${{matrix.version}}
+          fi
 
       - name: Restore CPM cache
         env:
@@ -168,16 +172,22 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup python venv
+        run: |
+          python3 -m venv ${{github.workspace}}/test_venv
+          source ${{github.workspace}}/test_venv/bin/activate
+          echo "${{github.workspace}}/test_venv/bin" >> $GITHUB_PATH
+
       - name: Install build tools
         run: |
-          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh ${{env.DEFAULT_LLVM_VERSION}}
-          sudo apt install -y pipx ninja-build clang-tidy-${{env.DEFAULT_LLVM_VERSION}} clang-format-${{env.DEFAULT_LLVM_VERSION}}
+          export DISTRO=$(lsb_release -cs)
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{env.DEFAULT_LLVM_VERSION}} main
+          sudo apt update && sudo apt install -y ninja-build clang-tidy-${{env.DEFAULT_LLVM_VERSION}} clang-format-${{env.DEFAULT_LLVM_VERSION}}
 
       - name: Install cmake-format
         run: |
-          pipx install cmakelang
-          pipx inject cmakelang pyyaml
-          echo "/opt/pipx_bin" >> $GITHUB_PATH
+          pip install cmakelang pyyaml
 
       - name: Restore CPM cache
         env:
@@ -220,12 +230,10 @@ jobs:
           - compiler: clang
             cc: "clang"
             cxx: "clang++"
-            install: sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 21
-            toolchain_root: "/usr/lib/llvm-21"
+            toolchain_root: "/usr/lib/llvm-22"
           - compiler: gcc
             cc: "gcc-14"
             cxx: "g++-14"
-            install: sudo apt update && sudo apt install -y gcc-14 g++-14
             toolchain_root: "/usr"
 
     steps:
@@ -233,8 +241,14 @@ jobs:
 
       - name: Install build tools
         run: |
-          ${{ matrix.install }}
-          sudo apt install -y ninja-build
+          if [[ "${{matrix.compiler}}" == "clang" ]]; then
+            export DISTRO=$(lsb_release -cs)
+            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+            sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{env.DEFAULT_LLVM_VERSION}} main
+            sudo apt update && sudo apt install -y ninja-build clang-${{env.DEFAULT_LLVM_VERSION}}
+          else
+            sudo apt update && sudo apt install -y ninja-build ${{matrix.cc}} ${{matrix.cxx}}
+          fi
 
       - name: Restore CPM cache
         env:
@@ -351,8 +365,10 @@ jobs:
 
       - name: Install build tools
         run: |
-          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh ${{env.MULL_LLVM_MAJOR_VERSION}}
-          sudo apt install -y ninja-build
+          export DISTRO=$(lsb_release -cs)
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{env.MULL_LLVM_MAJOR_VERSION}} main
+          sudo apt update && sudo apt install -y ninja-build clang-${{env.MULL_LLVM_MAJOR_VERSION}}
 
       - name: Install mull
         env:


### PR DESCRIPTION
Problem:
- Clang 22 is released and relatively stable; this repo doesn't yet build with it.

Solution:
- Add clang-22 to CI.