### PR TITLE
:construction_worker: Change github runners

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   configure:
     name: Configure Github Pages Publishing
-    runs-on: &runner ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: &runner ${{ github.repository_owner == 'intel' && 'intel-azure-' || '' }}ubuntu-24.04
     outputs:
       enable_publish: ${{ steps.check.outputs.isfork == 'NO' }}
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build_and_test_24:
-    runs-on: &runner ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: &runner ${{ github.repository_owner == 'intel' && 'intel-azure-' || '' }}ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -247,15 +247,12 @@ jobs:
 
       - *save_cpm_cache
 
-      # https://github.com/actions/runner-images/issues/9524
-      - name: Fix kernel mmap rnd bits
-        # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
-        # high-entropy ASLR in much newer kernels that GitHub runners are
-        # using leading to random crashes: https://reviews.llvm.org/D148280
-        run: sudo sysctl vm.mmap_rnd_bits=28
-
       - name: Build Unit Tests
-        run: cmake --build ${{github.workspace}}/build -t unit_tests
+        run: |
+          if [[ "${{matrix.sanitizer}}" == "thread" ]]; then
+            sudo sysctl vm.mmap_rnd_bits=28
+          fi
+          cmake --build ${{github.workspace}}/build -t unit_tests
 
   valgrind:
     runs-on: *runner

--- a/.github/workflows/usage_test.yml
+++ b/.github/workflows/usage_test.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   usage_test:
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-azure-' || '' }}ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Problem:
- The existing Intel github runners will no longer be supported.

Solution:
- Switch to new runners.