### PR TITLE
:white_check_mark: :bug: Fix output under TAP reporter

### DIFF
--- a/test/atomic_standard_policy.cpp
+++ b/test/atomic_standard_policy.cpp
@@ -32,9 +32,10 @@ TEST_CASE("standard policy implements store", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements load and store atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{17};
+    bool r;
     auto t1 = std::thread([&] {
         auto x = atomic::load(val);
-        CHECK((x == 17 or x == 18));
+        r = ((x == 17 or x == 18));
     });
     auto t2 = std::thread([&] {
         auto x = atomic::load(val);
@@ -42,6 +43,7 @@ TEST_CASE("standard policy implements load and store atomically",
     });
     t1.join();
     t2.join();
+    CHECK(r);
     CHECK(val == 18);
 }
 
@@ -54,13 +56,16 @@ TEST_CASE("standard policy implements exchange", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements exchange atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{17};
+    bool r1, r2;
     auto t1 = std::thread([&] {
         auto x = atomic::load(val);
-        CHECK((x == 17 or x == 1337));
+        r1 = ((x == 17 or x == 1337));
     });
-    auto t2 = std::thread([&] { CHECK(atomic::exchange(val, 1337) == 17); });
+    auto t2 = std::thread([&] { r2 = (atomic::exchange(val, 1337) == 17); });
     t1.join();
     t2.join();
+    CHECK(r1);
+    CHECK(r2);
     CHECK(val == 1337);
 }
 
@@ -73,13 +78,16 @@ TEST_CASE("standard policy implements fetch_add", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements fetch_add atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{17};
+    bool r1, r2;
     auto t1 = std::thread([&] {
         auto x = atomic::load(val);
-        CHECK((x == 17 or x == 18));
+        r1 = ((x == 17 or x == 18));
     });
-    auto t2 = std::thread([&] { CHECK(atomic::fetch_add(val, 1) == 17); });
+    auto t2 = std::thread([&] { r2 = (atomic::fetch_add(val, 1) == 17); });
     t1.join();
     t2.join();
+    CHECK(r1);
+    CHECK(r2);
     CHECK(val == 18);
 }
 
@@ -92,13 +100,16 @@ TEST_CASE("standard policy implements fetch_sub", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements fetch_sub atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{17};
+    bool r1, r2;
     auto t1 = std::thread([&] {
         auto x = atomic::load(val);
-        CHECK((x == 17 or x == 16));
+        r1 = ((x == 17 or x == 16));
     });
-    auto t2 = std::thread([&] { CHECK(atomic::fetch_sub(val, 1) == 17); });
+    auto t2 = std::thread([&] { r2 = (atomic::fetch_sub(val, 1) == 17); });
     t1.join();
     t2.join();
+    CHECK(r1);
+    CHECK(r2);
     CHECK(val == 16);
 }
 
@@ -111,14 +122,17 @@ TEST_CASE("standard policy implements fetch_and", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements fetch_and atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{0b101};
+    bool r1, r2;
     auto t1 = std::thread([&] {
         auto x = atomic::load(val);
-        CHECK((x == 0b101 or x == 0));
+        r1 = ((x == 0b101 or x == 0));
     });
     auto t2 =
-        std::thread([&] { CHECK(atomic::fetch_and(val, 0b10) == 0b101); });
+        std::thread([&] { r2 = (atomic::fetch_and(val, 0b10) == 0b101); });
     t1.join();
     t2.join();
+    CHECK(r1);
+    CHECK(r2);
     CHECK(val == 0);
 }
 
@@ -131,13 +145,16 @@ TEST_CASE("standard policy implements fetch_or", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements fetch_or atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{0b101};
+    bool r1, r2;
     auto t1 = std::thread([&] {
         auto x = atomic::load(val);
-        CHECK((x == 0b101 or x == 0b111));
+        r1 = ((x == 0b101 or x == 0b111));
     });
-    auto t2 = std::thread([&] { CHECK(atomic::fetch_or(val, 0b10) == 0b101); });
+    auto t2 = std::thread([&] { r2 = (atomic::fetch_or(val, 0b10) == 0b101); });
     t1.join();
     t2.join();
+    CHECK(r1);
+    CHECK(r2);
     CHECK(val == 0b111);
 }
 
@@ -150,13 +167,16 @@ TEST_CASE("standard policy implements fetch_xor", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements fetch_xor atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{0b101};
+    bool r1, r2;
     auto t1 = std::thread([&] {
         auto x = atomic::load(val);
-        CHECK((x == 0b101 or x == 0b100));
+        r1 = ((x == 0b101 or x == 0b100));
     });
-    auto t2 = std::thread([&] { CHECK(atomic::fetch_xor(val, 0b1) == 0b101); });
+    auto t2 = std::thread([&] { r2 = (atomic::fetch_xor(val, 0b1) == 0b101); });
     t1.join();
     t2.join();
+    CHECK(r1);
+    CHECK(r2);
     CHECK(val == 0b100);
 }
 


### PR DESCRIPTION
Picked from #113 

Defer the checks to main thread.