### PR TITLE
:white_check_mark: :bug: Fix output under TAP reporter

### DIFF
--- a/test/atomic_standard_policy.cpp
+++ b/test/atomic_standard_policy.cpp
@@ -32,16 +32,15 @@ TEST_CASE("standard policy implements store", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements load and store atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{17};
-    auto t1 = std::thread([&] {
-        auto x = atomic::load(val);
-        CHECK((x == 17 or x == 18));
-    });
+    std::uint32_t t1_value{};
+    auto t1 = std::thread([&] { t1_value += atomic::load(val); });
     auto t2 = std::thread([&] {
         auto x = atomic::load(val);
         atomic::store(val, ++x);
     });
     t1.join();
     t2.join();
+    CHECK((t1_value == 17 or t1_value == 18));
     CHECK(val == 18);
 }
 
@@ -54,13 +53,14 @@ TEST_CASE("standard policy implements exchange", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements exchange atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{17};
-    auto t1 = std::thread([&] {
-        auto x = atomic::load(val);
-        CHECK((x == 17 or x == 1337));
-    });
-    auto t2 = std::thread([&] { CHECK(atomic::exchange(val, 1337) == 17); });
+    std::uint32_t t1_value{};
+    std::uint32_t t2_value{};
+    auto t1 = std::thread([&] { t1_value += atomic::load(val); });
+    auto t2 = std::thread([&] { t2_value += atomic::exchange(val, 1337); });
     t1.join();
     t2.join();
+    CHECK((t1_value == 17 or t1_value == 1337));
+    CHECK(t2_value == 17);
     CHECK(val == 1337);
 }
 
@@ -73,13 +73,14 @@ TEST_CASE("standard policy implements fetch_add", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements fetch_add atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{17};
-    auto t1 = std::thread([&] {
-        auto x = atomic::load(val);
-        CHECK((x == 17 or x == 18));
-    });
-    auto t2 = std::thread([&] { CHECK(atomic::fetch_add(val, 1) == 17); });
+    std::uint32_t t1_value{};
+    std::uint32_t t2_value{};
+    auto t1 = std::thread([&] { t1_value += atomic::load(val); });
+    auto t2 = std::thread([&] { t2_value += atomic::fetch_add(val, 1); });
     t1.join();
     t2.join();
+    CHECK((t1_value == 17 or t1_value == 18));
+    CHECK(t2_value == 17);
     CHECK(val == 18);
 }
 
@@ -92,13 +93,14 @@ TEST_CASE("standard policy implements fetch_sub", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements fetch_sub atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{17};
-    auto t1 = std::thread([&] {
-        auto x = atomic::load(val);
-        CHECK((x == 17 or x == 16));
-    });
-    auto t2 = std::thread([&] { CHECK(atomic::fetch_sub(val, 1) == 17); });
+    std::uint32_t t1_value{};
+    std::uint32_t t2_value{};
+    auto t1 = std::thread([&] { t1_value += atomic::load(val); });
+    auto t2 = std::thread([&] { t2_value += atomic::fetch_sub(val, 1); });
     t1.join();
     t2.join();
+    CHECK((t1_value == 17 or t1_value == 16));
+    CHECK(t2_value == 17);
     CHECK(val == 16);
 }
 
@@ -111,14 +113,14 @@ TEST_CASE("standard policy implements fetch_and", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements fetch_and atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{0b101};
-    auto t1 = std::thread([&] {
-        auto x = atomic::load(val);
-        CHECK((x == 0b101 or x == 0));
-    });
-    auto t2 =
-        std::thread([&] { CHECK(atomic::fetch_and(val, 0b10) == 0b101); });
+    std::uint32_t t1_value{};
+    std::uint32_t t2_value{};
+    auto t1 = std::thread([&] { t1_value += atomic::load(val); });
+    auto t2 = std::thread([&] { t2_value += atomic::fetch_and(val, 0b10); });
     t1.join();
     t2.join();
+    CHECK((t1_value == 0b101 or t1_value == 0));
+    CHECK(t2_value == 0b101);
     CHECK(val == 0);
 }
 
@@ -131,13 +133,14 @@ TEST_CASE("standard policy implements fetch_or", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements fetch_or atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{0b101};
-    auto t1 = std::thread([&] {
-        auto x = atomic::load(val);
-        CHECK((x == 0b101 or x == 0b111));
-    });
-    auto t2 = std::thread([&] { CHECK(atomic::fetch_or(val, 0b10) == 0b101); });
+    std::uint32_t t1_value{};
+    std::uint32_t t2_value{};
+    auto t1 = std::thread([&] { t1_value += atomic::load(val); });
+    auto t2 = std::thread([&] { t2_value += atomic::fetch_or(val, 0b10); });
     t1.join();
     t2.join();
+    CHECK((t1_value == 0b111 or t1_value == 0b101));
+    CHECK(t2_value == 0b101);
     CHECK(val == 0b111);
 }
 
@@ -150,13 +153,14 @@ TEST_CASE("standard policy implements fetch_xor", "[atomic_standard_policy]") {
 TEST_CASE("standard policy implements fetch_xor atomically",
           "[atomic_standard_policy]") {
     std::uint32_t val{0b101};
-    auto t1 = std::thread([&] {
-        auto x = atomic::load(val);
-        CHECK((x == 0b101 or x == 0b100));
-    });
-    auto t2 = std::thread([&] { CHECK(atomic::fetch_xor(val, 0b1) == 0b101); });
+    std::uint32_t t1_value{};
+    std::uint32_t t2_value{};
+    auto t1 = std::thread([&] { t1_value += atomic::load(val); });
+    auto t2 = std::thread([&] { t2_value += atomic::fetch_xor(val, 0b1); });
     t1.join();
     t2.join();
+    CHECK((t1_value == 0b100 or t1_value == 0b101));
+    CHECK(t2_value == 0b101);
     CHECK(val == 0b100);
 }
 


### PR DESCRIPTION
Problem:
- Catch2 thread safety is very limited. Even when specifying `-DCATCH_CONFIG_THREAD_SAFE_ASSERTIONS`, many things are not thread-safe.
- Not all test reporters are thread-safe. (e.g. `JSON`)
- Those that are "more" thread-safe may still have interleaved output. (e.g. `tap`)
- Therefore calling `CHECK` is not thread-safe in general.

Solution:
- Serialize calls to `CHECK` on the main thread only.

Note:
- #114 is failing mutation tests; this is a take that makes the mull tests more robust.
- After experimenting with `-DCATCH_CONFIG_THREAD_SAFE_ASSERTIONS` my conclusion is that Catch2 just doesn't support thread safety very well. `CHECK` may be thread-safe with the default reporter. Anything else is out.
- Even with `-DCATCH_CONFIG_THREAD_SAFE_ASSERTIONS`, without this change:
  - The `tap` reporter produces interleaved output
  - The `JSON` reporter frequently crashes
  - Basically anything that is not the default fails either ASan or TSan or both.
