### PR TITLE
:construction_worker: Streamline github workflows

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -116,9 +116,9 @@ jobs:
       - name: Install build tools
         run: |
           if [[ "${{matrix.compiler}}" == "clang" ]]; then
-            export DISTRO=$(lsb_release -cs)
+            DISTRO=$(lsb_release -cs)
             wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-            sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{matrix.version}} main
+            sudo add-apt-repository -y deb "https://apt.llvm.org/$DISTRO/" "llvm-toolchain-$DISTRO-${{matrix.version}}" main
             sudo apt update && sudo apt install -y ninja-build clang-${{matrix.version}} libc++-${{matrix.version}}-dev libc++abi-${{matrix.version}}-dev
           else
             sudo apt update && sudo apt install -y ninja-build gcc-${{matrix.version}} g++-${{matrix.version}}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest --output-on-failure -j $(nproc) -C ${{matrix.build_type}}
+        run: ctest --output-on-failure -j -C ${{matrix.build_type}}
 
   quality_checks_pass:
     runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
@@ -166,7 +166,7 @@ jobs:
           ref: ${{github.base_ref}}
 
       - name: Extract target branch SHA
-        run: echo "branch=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        run: echo "branch=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         id: target_branch
 
       - name: Checkout PR branch
@@ -176,13 +176,13 @@ jobs:
         run: |
           python3 -m venv ${{github.workspace}}/test_venv
           source ${{github.workspace}}/test_venv/bin/activate
-          echo "${{github.workspace}}/test_venv/bin" >> $GITHUB_PATH
+          echo "${{github.workspace}}/test_venv/bin" >> "$GITHUB_PATH"
 
       - name: Install build tools
         run: |
-          export DISTRO=$(lsb_release -cs)
+          DISTRO=$(lsb_release -cs)
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{env.DEFAULT_LLVM_VERSION}} main
+          sudo add-apt-repository -y deb "https://apt.llvm.org/$DISTRO/" "llvm-toolchain-$DISTRO-${{env.DEFAULT_LLVM_VERSION}}" main
           sudo apt update && sudo apt install -y ninja-build clang-tidy-${{env.DEFAULT_LLVM_VERSION}} clang-format-${{env.DEFAULT_LLVM_VERSION}}
 
       - name: Install cmake-format
@@ -242,9 +242,9 @@ jobs:
       - name: Install build tools
         run: |
           if [[ "${{matrix.compiler}}" == "clang" ]]; then
-            export DISTRO=$(lsb_release -cs)
+            DISTRO=$(lsb_release -cs)
             wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-            sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{env.DEFAULT_LLVM_VERSION}} main
+            sudo add-apt-repository -y deb "https://apt.llvm.org/$DISTRO/" "llvm-toolchain-$DISTRO-${{env.DEFAULT_LLVM_VERSION}}" main
             sudo apt update && sudo apt install -y ninja-build clang-${{env.DEFAULT_LLVM_VERSION}}
           else
             sudo apt update && sudo apt install -y ninja-build ${{matrix.cc}} ${{matrix.cxx}}
@@ -328,35 +328,35 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         run: |
-          ctest --output-on-failure -j $(nproc) -E EXPECT_FAIL -T memcheck
+          ctest --output-on-failure -j -E EXPECT_FAIL -T memcheck
 
           LOGFILE=$(ls ./Testing/Temporary/LastDynamicAnalysis_*.log)
           FAILSIZE=$(du -c ./Testing/Temporary/MemoryChecker.* | tail -1 | cut -f1)
-          echo "<details>" >> $GITHUB_STEP_SUMMARY
+          { echo "<details>";
+          echo "<summary>"; } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "<summary>" >> $GITHUB_STEP_SUMMARY
-          if [ $FAILSIZE != "0" ]; then
-            echo "Failing tests:" | tee -a $GITHUB_STEP_SUMMARY
+          if [ "$FAILSIZE" != "0" ]; then
+            echo "Failing tests:" | tee -a "$GITHUB_STEP_SUMMARY"
           else
-            echo "No failing tests" >> $GITHUB_STEP_SUMMARY
+            echo "No failing tests" >> "$GITHUB_STEP_SUMMARY"
           fi
-          echo "</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "</summary>" >> "$GITHUB_STEP_SUMMARY"
 
           for f in ./Testing/Temporary/MemoryChecker.*
           do
-            if [ -s $f ]; then
-              FILENAME=$(cd $(dirname $f) && pwd)/$(basename $f)
-              TEST_COMMAND=$(grep $FILENAME $LOGFILE)
-              echo "" | tee -a $GITHUB_STEP_SUMMARY
+            if [ -s "$f" ]; then
+              FILENAME=$(realpath "$f")
+              TEST_COMMAND=$(grep "$FILENAME" "$LOGFILE")
+              echo "" | tee -a "$GITHUB_STEP_SUMMARY"
               echo "========================================"
-              echo $TEST_COMMAND | tee -a $GITHUB_STEP_SUMMARY
+              echo "$TEST_COMMAND" | tee -a "$GITHUB_STEP_SUMMARY"
               echo "--------------------"
-              cat $f
+              cat "$f"
             fi
           done
 
-          echo "</details>" >> $GITHUB_STEP_SUMMARY
-          test $FAILSIZE = "0"
+          echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+          test "$FAILSIZE" = "0"
 
   mutate:
     runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
@@ -365,9 +365,9 @@ jobs:
 
       - name: Install build tools
         run: |
-          export DISTRO=$(lsb_release -cs)
+          DISTRO=$(lsb_release -cs)
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{env.MULL_LLVM_MAJOR_VERSION}} main
+          sudo add-apt-repository -y deb "https://apt.llvm.org/$DISTRO/" "llvm-toolchain-$DISTRO-${{env.MULL_LLVM_MAJOR_VERSION}}" main
           sudo apt update && sudo apt install -y ninja-build clang-${{env.MULL_LLVM_MAJOR_VERSION}}
 
       - name: Install mull

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build_and_test_24:
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: &runner ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +111,7 @@ jobs:
             stdlib: libc++
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: &checkout actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install build tools
         run: |
@@ -124,7 +124,8 @@ jobs:
             sudo apt update && sudo apt install -y ninja-build gcc-${{matrix.version}} g++-${{matrix.version}}
           fi
 
-      - name: Restore CPM cache
+      - &restore_cpm_cache
+        name: Restore CPM cache
         env:
           cache-name: cpm-cache-0
         id: cpm-cache-restore
@@ -141,7 +142,8 @@ jobs:
           CXX: ${{matrix.toolchain_root}}/bin/${{matrix.cxx}}
         run: cmake -B ${{github.workspace}}/build -DCMAKE_CXX_STANDARD=${{matrix.cxx_standard}} -DCMAKE_CXX_FLAGS_INIT=${{matrix.cxx_flags}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCPM_SOURCE_CACHE=~/cpm-cache
 
-      - name: Save CPM cache
+      - &save_cpm_cache
+        name: Save CPM cache
         env:
           cache-name: cpm-cache-0
         if: steps.cpm-cache-restore.outputs.cache-hit != 'true'
@@ -158,10 +160,10 @@ jobs:
         run: ctest --output-on-failure -j -C ${{matrix.build_type}}
 
   quality_checks_pass:
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: *runner
     steps:
       - name: Checkout target branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: *checkout
         with:
           ref: ${{github.base_ref}}
 
@@ -170,7 +172,7 @@ jobs:
         id: target_branch
 
       - name: Checkout PR branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: *checkout
 
       - name: Setup python venv
         run: |
@@ -189,16 +191,7 @@ jobs:
         run: |
           pip install cmakelang pyyaml
 
-      - name: Restore CPM cache
-        env:
-          cache-name: cpm-cache-0
-        id: cpm-cache-restore
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/cpm-cache
-          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
-          restore-keys: |
-            ${{runner.os}}-${{env.cache-name}}-
+      - *restore_cpm_cache
 
       - name: Configure CMake
         env:
@@ -207,20 +200,13 @@ jobs:
           PR_TARGET_BRANCH: ${{ steps.target_branch.outputs.branch }}
         run: cmake -B ${{github.workspace}}/build -DCMAKE_CXX_STANDARD=${{env.DEFAULT_CXX_STANDARD}} -DCPM_SOURCE_CACHE=~/cpm-cache
 
-      - name: Save CPM cache
-        env:
-          cache-name: cpm-cache-0
-        if: steps.cpm-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/cpm-cache
-          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+      - *save_cpm_cache
 
       - name: Run quality checks
         run: cmake --build ${{github.workspace}}/build -t ci-quality
 
   sanitize:
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: *runner
     strategy:
       fail-fast: false
       matrix:
@@ -237,7 +223,7 @@ jobs:
             toolchain_root: "/usr"
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: *checkout
 
       - name: Install build tools
         run: |
@@ -250,16 +236,7 @@ jobs:
             sudo apt update && sudo apt install -y ninja-build ${{matrix.cc}} ${{matrix.cxx}}
           fi
 
-      - name: Restore CPM cache
-        env:
-          cache-name: cpm-cache-0
-        id: cpm-cache-restore
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/cpm-cache
-          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
-          restore-keys: |
-            ${{runner.os}}-${{env.cache-name}}-
+      - *restore_cpm_cache
 
       - name: Configure CMake
         env:
@@ -268,14 +245,7 @@ jobs:
           SANITIZERS: ${{matrix.sanitizer}}
         run: cmake -B ${{github.workspace}}/build -DCMAKE_CXX_STANDARD=${{env.DEFAULT_CXX_STANDARD}} -DCPM_SOURCE_CACHE=~/cpm-cache
 
-      - name: Save CPM cache
-        env:
-          cache-name: cpm-cache-0
-        if: steps.cpm-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/cpm-cache
-          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+      - *save_cpm_cache
 
       # https://github.com/actions/runner-images/issues/9524
       - name: Fix kernel mmap rnd bits
@@ -288,24 +258,15 @@ jobs:
         run: cmake --build ${{github.workspace}}/build -t unit_tests
 
   valgrind:
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: *runner
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: *checkout
 
       - name: Install build tools
         run: |
           sudo apt update && sudo apt install -y gcc-${{env.DEFAULT_GCC_VERSION}} g++-${{env.DEFAULT_GCC_VERSION}} ninja-build valgrind
 
-      - name: Restore CPM cache
-        env:
-          cache-name: cpm-cache-0
-        id: cpm-cache-restore
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/cpm-cache
-          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
-          restore-keys: |
-            ${{runner.os}}-${{env.cache-name}}-
+      - *restore_cpm_cache
 
       - name: Configure CMake
         env:
@@ -313,14 +274,7 @@ jobs:
           CXX: "/usr/bin/g++-${{env.DEFAULT_GCC_VERSION}}"
         run: cmake -B ${{github.workspace}}/build -DCMAKE_CXX_STANDARD=${{env.DEFAULT_CXX_STANDARD}} -DCPM_SOURCE_CACHE=~/cpm-cache
 
-      - name: Save CPM cache
-        env:
-          cache-name: cpm-cache-0
-        if: steps.cpm-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/cpm-cache
-          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+      - *save_cpm_cache
 
       - name: Build Unit Tests
         run: cmake --build ${{github.workspace}}/build -t build_unit_tests
@@ -359,9 +313,9 @@ jobs:
           test "$FAILSIZE" = "0"
 
   mutate:
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: *runner
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: *checkout
 
       - name: Install build tools
         run: |
@@ -378,16 +332,7 @@ jobs:
           wget -O "$MULL_DEB" https://github.com/mull-project/mull/releases/download/${{env.MULL_VERSION}}/${{env.mull-pkg}}
           sudo dpkg -i "$MULL_DEB"
 
-      - name: Restore CPM cache
-        env:
-          cache-name: cpm-cache-0
-        id: cpm-cache-restore
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/cpm-cache
-          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
-          restore-keys: |
-            ${{runner.os}}-${{env.cache-name}}-
+      - *restore_cpm_cache
 
       - name: Configure CMake
         env:
@@ -395,20 +340,13 @@ jobs:
           CXX: "/usr/lib/llvm-${{env.MULL_LLVM_MAJOR_VERSION}}/bin/clang++"
         run: cmake -B ${{github.workspace}}/build -DCMAKE_CXX_STANDARD=${{env.DEFAULT_CXX_STANDARD}} -DCPM_SOURCE_CACHE=~/cpm-cache
 
-      - name: Save CPM cache
-        env:
-          cache-name: cpm-cache-0
-        if: steps.cpm-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/cpm-cache
-          key: ${{runner.os}}-${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+      - *save_cpm_cache
 
       - name: Build and run mull tests
         run: cmake --build build -t mull_tests
 
   merge_ok:
-    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
+    runs-on: *runner
     needs: [build_and_test_24, mutate, quality_checks_pass, sanitize, valgrind]
     if: ${{ !cancelled() }}
     steps:


### PR DESCRIPTION
Problem:
- The github actions don't lint cleanly with actionlint.
- Steps in the test workflow are repeated.

Solution:
- Fix the lint issues.
- Use YAML anchors and aliases to avoid repetition.

Note:
- https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases