### PR TITLE
:art: Fix valgrind exclusions for Python tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -282,7 +282,7 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         run: |
-          ctest --output-on-failure -j -E EXPECT_FAIL -T memcheck
+          ctest --output-on-failure -j -E "EXPECT_FAIL|PYTHON" -T memcheck
 
           LOGFILE=$(ls ./Testing/Temporary/LastDynamicAnalysis_*.log)
           FAILSIZE=$(du -c ./Testing/Temporary/MemoryChecker.* | tail -1 | cut -f1)


### PR DESCRIPTION
Problem:
- Valgrind does not exclude Python tests.

Solution:
- Exclude Python tests.

Note:
- This is fixed upstream in the CICD repo.