### PR TITLE
:construction_worker: Use black for python formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ project(
     DESCRIPTION
         "A header-only C++ library that provides low-level concurrency hooks.")
 
+set(INFRA_PYTHON_FORMATTER black)
+
 include(cmake/get_cpm.cmake)
 if(PROJECT_IS_TOP_LEVEL)
     cpmaddpackage("gh:intel/cicd-repo-infrastructure#dev")


### PR DESCRIPTION
Problem:
- The default python formatter from CICD is ruff, but this branch is not set up to use it.

Solution:
- Continue using black.